### PR TITLE
Remove the behavior of altering user entered dates when invalid

### DIFF
--- a/docassemble/VirtualCourtToolbox/data/static/textDateInput.js
+++ b/docassemble/VirtualCourtToolbox/data/static/textDateInput.js
@@ -15,20 +15,27 @@ $(document).on('daPageLoad', function(){
 	var yearElement = $('<input type="text" class="form-control" type="number" min="1901" max="2020" required>');
 	var dayElement = $('<input type="text" class="form-control" type="number" min="1" max="31"  required>' );
 	var monthElement = $('<select class="form-control" style="width:7.5em" required>');
-		
-	var dateEntered;	
-	if ($(dateElement).val()){
-	    var utcDate = new Date($(dateElement).val());
-	    dateEntered = new Date(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate());
-	}
-	else{
-	    dateEntered = null;
-	}
+      
+  // If we're returning to a variable that has already been defined
+  // prepare to use that variable's values
+  var dateParts;
+  if ( $(dateElement).val() ) {
+    dateParts = $(dateElement).val().split( '/' );
+    dateParts.forEach( function( part, index, dateParts ) {
+      dateParts[ index ] = parseInt( part );
+    });
+  } else {
+    dateParts = null;
+  }
+      
+  // Create contents of visible input fields
 	
+  // "No month selected" option
 	var opt = $("<option>");
 	opt.val("");
 	opt.text("    ");
 	monthElement.append(opt);
+  // Add every calendar month (based on user's computer's date system? lanugage?)
 	for(var month=0; month < 12; month++){
 	    opt = $("<option>");
 	    if (month < 9){
@@ -39,15 +46,19 @@ $(document).on('daPageLoad', function(){
 	    }
 	    var dt = new Date(1970, month, 1);
 	    opt.text(dt.toLocaleString('default', { month: 'long' }));
-	    if (dateEntered && month == dateEntered.getMonth()){
-		opt.attr('selected', 'selected');
-	    }
+      // Use previous values if possible
+      if ( dateParts && parseInt( opt.val()) == dateParts[ 0 ]) {
+        opt.attr('selected', 'selected');
+      }
 	    monthElement.append(opt);
 	}
-	if (dateEntered) {		
-		dayElement.attr('value', dateEntered.getDate());
-		yearElement.attr('value', dateEntered.getFullYear());
+
+  // Use previous values if possible
+	if ( dateParts ) {		
+		dayElement.val( dateParts[ 1 ]);
+		yearElement.val( dateParts[ 2 ]);
 	}
+
 	function updateDate(){
 		$(dateElement).val($(monthElement).val() + '/' + $(dayElement).val() + '/' + $(yearElement).val());		
 	}	


### PR DESCRIPTION
Spacing looks strange because the code uses tabs instead of spaces. I can fix that on another go around.

Not sure why git thinks that everything's been replaced.