### PR TITLE
Validate in `CustomDataType` instead of in YAML. Delete unused file.

### DIFF
--- a/docassemble/VirtualCourtToolbox/ThreePartDateDataType.py
+++ b/docassemble/VirtualCourtToolbox/ThreePartDateDataType.py
@@ -1,0 +1,17 @@
+from docassemble.base.util import CustomDataType, DAValidationError, word, as_datetime
+import re
+
+class ThreePartDateDataType( CustomDataType ):
+    name = 'textdate'
+    input_type = 'textdate'
+    jq_rule = 'textdate'
+    jq_message = word("This date doesn't look right")
+    @classmethod
+    def validate(cls, aDate):
+      # Try to change string into DADateTime
+      try:
+        as_datetime( aDate )
+        return True
+      # If error, date is not a valid DADateTime
+      except:
+        return False

--- a/docassemble/VirtualCourtToolbox/data/static/textDateInput.js
+++ b/docassemble/VirtualCourtToolbox/data/static/textDateInput.js
@@ -1,6 +1,6 @@
 //this is a revision of Jonathan Pyle's datereplace.js
 $(document).on('daPageLoad', function(){
-    $('input[type="textdate"]').each(function(){
+  $('input[type="textdate"]').each(function(){
 	var dateElement = this;
 	$(dateElement).hide();
 	$(dateElement).attr('type', 'hidden');
@@ -60,7 +60,7 @@ $(document).on('daPageLoad', function(){
 	}
 
 	function updateDate(){
-		$(dateElement).val($(monthElement).val() + '/' + $(dayElement).val() + '/' + $(yearElement).val());		
+		$(dateElement).val($(monthElement).val() + '/' + $(dayElement).val() + '/' + $(yearElement).val());	
 	}	
 	
 	$(dateElement).before(parentElement);	

--- a/docassemble/VirtualCourtToolbox/shortenURL.py
+++ b/docassemble/VirtualCourtToolbox/shortenURL.py
@@ -1,5 +1,0 @@
-#This is Jonathan's code, we just added a wrapper.
-import docassemble.base.functions
-class shortenMe:
-  def __init__(self, originalURL):
-    self.shortenedURL = docassemble.base.functions.temp_redirect(originalURL, 60*60*24*7, False, False)


### PR DESCRIPTION
We can move the js into here as well so that we don't have to include as many files. I just didn't want to do it at the same time.

Also, keeping the date validation function in `.misc` might be a useful toolbox tool, so I left it where it was. Would appreciate thoughts on that.